### PR TITLE
[v3] fix: AuthMe login race, LocalMode port override, and incomplete deop in stand-reset

### DIFF
--- a/auth-authme-package/index.ts
+++ b/auth-authme-package/index.ts
@@ -89,7 +89,13 @@ export default definePlugin<AuthAuthmeOptions>({
         // pool account outlives the run that created it. So wait for either prompt and answer
         // the one that actually arrived. Register is tested first because AuthMe's register
         // prompt names the password too, and would otherwise match the login pattern.
-        const joinIndex = player.getMessageBufferIndex();
+        //
+        // Hardcoded to 0 rather than `player.getMessageBufferIndex()`: the login prompt can
+        // arrive during the handshake, before this handler even runs, so reading the buffer
+        // index here can already be past it. Scanning from 0 risks matching a stale prompt from
+        // a previous connection, but this buffer is fresh per player and the loss of precision
+        // is worth never missing the real prompt.
+        const joinIndex = 0;
         const since = (index: number, pattern: RegExp): string | undefined =>
             player.messageBuffer.slice(index).find((m: string) => pattern.test(m));
 

--- a/example_plugin/src/test/e2e/plugins/stand-reset.ts
+++ b/example_plugin/src/test/e2e/plugins/stand-reset.ts
@@ -18,7 +18,7 @@ export default definePlugin({
         // and the tests that depend on this reset are excluded there anyway.
         if (!server.session.env.capabilities.console) return;
 
-        await server.executeAndWait(`minecraft:deop ${player.username}`);
+        await player.deOp();
         await server.executeAndWait(`minecraft:clear ${player.username}`);
     },
 });

--- a/gradle-plugin/plugwright-local/src/main/kotlin/me/drownek/plugwright/local/LocalMode.kt
+++ b/gradle-plugin/plugwright-local/src/main/kotlin/me/drownek/plugwright/local/LocalMode.kt
@@ -78,6 +78,7 @@ object LocalMode : PlugwrightMode<LocalEnvironmentSpec> {
             dependsOn(clean)
             runDir.set(spec.runDir)
             minecraftVersion.set(spec.minecraftVersion)
+            port.set(spec.port)
             pluginJar.set(ctx.projectPluginJar)
             pluginUrls.set(spec.pluginUrls)
             runDirFiles.set(spec.runDirFiles)

--- a/gradle-plugin/plugwright-local/src/main/kotlin/me/drownek/plugwright/local/PaperProvisionTask.kt
+++ b/gradle-plugin/plugwright-local/src/main/kotlin/me/drownek/plugwright/local/PaperProvisionTask.kt
@@ -32,6 +32,9 @@ abstract class PaperProvisionTask : DefaultTask() {
     abstract val minecraftVersion: Property<String>
 
     @get:Input
+    abstract val port: Property<Int>
+
+    @get:Input
     @get:Optional
     abstract val pluginJar: Property<File>
 
@@ -102,6 +105,16 @@ abstract class PaperProvisionTask : DefaultTask() {
                 lines.add("connection-throttle=0")
             }
 
+            val portLine = "server-port=${port.get()}"
+            val hasPort = lines.any { it.trim().startsWith("server-port=") }
+            if (hasPort) {
+                lines = lines.map { line ->
+                    if (line.trim().startsWith("server-port=")) portLine else line
+                }.toMutableList()
+            } else {
+                lines.add(portLine)
+            }
+
             // Disable spawn protection so tests can damage players near spawn
             val hasSpawnProtection = lines.any { it.trim().startsWith("spawn-protection=") }
             if (hasSpawnProtection) {
@@ -114,8 +127,11 @@ abstract class PaperProvisionTask : DefaultTask() {
 
             Files.write(serverProperties.toPath(), lines)
         } else {
-            logger.lifecycle("Creating server.properties with online-mode=false, connection-throttle=0 and spawn-protection=0")
-            Files.write(serverProperties.toPath(), listOf("online-mode=false", "connection-throttle=0", "spawn-protection=0"))
+            logger.lifecycle("Creating server.properties with online-mode=false, connection-throttle=0, spawn-protection=0 and server-port=${port.get()}")
+            Files.write(
+                serverProperties.toPath(),
+                listOf("online-mode=false", "connection-throttle=0", "spawn-protection=0", "server-port=${port.get()}")
+            )
         }
 
         configureBukkitSettings(runDirectory)


### PR DESCRIPTION
Three independent bugs @Drownek found testing #52 on a real stand. Small enough to land as their own PR rather than wait on the player-reuse rework.

## AuthMe login prompt missed during handshake

`auth-authme-package/index.ts` read `player.getMessageBufferIndex()` to mark where in the chat buffer to start scanning for the login/register prompt. But the prompt can arrive during the handshake, before that read happens — so the poll below started scanning from a point already past the prompt and hung waiting for something it had already missed.

Fixed by hardcoding `joinIndex = 0`. This buffer is fresh per player, so scanning from the start doesn't risk picking up a stale prompt from a previous connection.

## LocalMode ignores the configured port

`LocalEnvironmentSpec.port` was already wired into the runner config, so bots connected to whatever port the environment DSL specified. But `PaperProvisionTask` never wrote that port into `server.properties` — the server itself always came up on Paper's default, 25565, no matter what the config said. Anyone setting a custom port got a bot pointed at a port nothing was listening on.

Added a `port` input to `PaperProvisionTask`, wired from `spec.port` in `LocalMode.registerTasks`, and now written as `server-port=` alongside the existing `online-mode`/`connection-throttle`/`spawn-protection` patching.

## `stand-reset.ts` deop doesn't clear ability state

The reset plugin ran the raw `minecraft:deop` command, which strips operator status server-side but leaves nothing telling the bot's own tracked state that it happened. `player.abilities` kept reporting `op` for an account the server no longer trusted.

Swapped in `player.deOp()`, which sends the same command and clears the local `op` mark to match.

## Testing

- `:plugwright-local:compileKotlin` — passes
- `tsc --noEmit` on `auth-authme-package` — clean

Closes #54