### PR TITLE
[v3] fix: fall back to login when the AuthMe reconnect prompt never arrives

### DIFF
--- a/auth-authme-package/index.ts
+++ b/auth-authme-package/index.ts
@@ -97,6 +97,12 @@ export default definePlugin<AuthAuthmeOptions>({
         const since = (index: number, pattern: RegExp): string | undefined =>
             player.messageBuffer.slice(index).find((m: string) => pattern.test(m));
 
+        // The server occasionally sends no prompt at all on a reconnect (#57) — AuthMe still
+        // considers the account logged in from a connection that never fully closed. Rather
+        // than fail the whole test over one missing prompt, assume login (never registration:
+        // a silent reconnect can only happen to an account that already exists) and let the
+        // command below run into either a real prompt AuthMe queued up in the meantime, or an
+        // "already logged in" reply — both success/authenticated patterns already match it.
         const isRegistration = await poll(
             () => {
                 if (since(joinIndex, registerPrompt)) return true;
@@ -107,7 +113,7 @@ export default definePlugin<AuthAuthmeOptions>({
                 timeout: resolved.timeoutMs,
                 message: `authme: never saw a login or register prompt for "${account.username}"`,
             },
-        );
+        ).catch(() => false);
 
         // Everything below only looks at messages newer than the command. A server's greeting
         // often carries a word like "welcome", which would otherwise pass for confirmation


### PR DESCRIPTION
Closes #57.

A pool account reconnecting sometimes gets no login/register prompt at all — AuthMe stays silent, and the plugin burned its full 15s timeout waiting for something that was never coming. One missed prompt failed the whole connection, and on `v3-dev` that stranded the bot online, so the next test got kicked with "already playing" and the failure cascaded through the rest of the run.

The plugin now catches that timeout and assumes login (never registration — a silent reconnect can only happen to an account that already exists), then sends `/login` anyway. `successPattern` and `authenticatedPattern` already match "already logged in" as a substring, so if AuthMe considers the session still active, the extra command just gets accepted instead of leaving the bot stuck.

Root cause of the missing prompt itself is still open — this only stops it from taking the rest of the run down with it.

**Verified on both stands** (`example_plugin`, `feat/53-serial-identity` → this branch):
- `plugwrightTestLocal`: 50/50 pass
- `plugwrightTestStand` (hand-started server, same as #57's repro): 44/44 pass, 6 skip — 0 fail, vs. 2 failed in the run that surfaced #57