### PR TITLE
[v3] Run ExternalMode (stand) suite in CI in addition to LocalMode

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,6 @@ jobs:
   test-example-plugin:
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
     runs-on: ubuntu-latest
-    env:
-      # Test-only credentials for the Paper server this job starts and tears down itself.
-      PLUGWRIGHT_RCON_PASSWORD: plugwright
-      PLUGWRIGHT_BOT_PASSWORD: plugwright
 
     steps:
       - uses: actions/checkout@v4
@@ -36,17 +32,43 @@ jobs:
           java-version: "17"
           node-version: "24"
           working-directory: "./example_plugin"
-      # LocalMode's own server launch resolves a Java 21 toolchain (build.gradle.kts pins
-      # languageVersion 21 for Paper 1.21.11) regardless of the Gradle-daemon JDK above - Gradle
-      # downloads it on demand. start.sh has no such resolution, it just runs whatever "java" is
-      # on PATH, so put a real JDK 21 there before it needs one.
+
+  test-example-plugin-stand:
+    if: "!contains(github.event.head_commit.message, 'skip-ci')"
+    runs-on: ubuntu-latest
+    env:
+      # Test-only credentials for the Paper server this job starts and tears down itself.
+      PLUGWRIGHT_RCON_PASSWORD: plugwright
+      PLUGWRIGHT_BOT_PASSWORD: plugwright
+
+    steps:
+      - uses: actions/checkout@v4
+      # Same duplicated build as test-example-plugin: this job runs on its own runner, in
+      # parallel with it, so it can't share that job's npm install/build output.
+      - name: Build the local npm packages
+        run: |
+          npm run install:packages
+          npm run build:packages
+      # Running in parallel with test-example-plugin means this job can't reuse its
+      # generated/local/run/ either - provision the same Paper server here instead of just
+      # running plugwrightTest, which would also run (and duplicate) the local suite.
+      - uses: drownek/plugwright-action@v1
+        with:
+          java-version: "17"
+          node-version: "24"
+          working-directory: "./example_plugin"
+          gradle-args: plugwrightProvisionLocal
+      # The provisioning above resolves a Java 21 toolchain for itself (build.gradle.kts pins
+      # languageVersion 21 for Paper 1.21.11), but that's Gradle's own on-demand download, not
+      # something start.sh can reach - it just runs whatever "java" is on PATH, which
+      # plugwright-action pinned to 17 above for the Gradle daemon. Put a real JDK 21 there.
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "21"
-      # The LocalMode run above leaves Paper, cache and libraries under generated/local/run/ -
-      # stand reuses that same directory (build.gradle.kts points it at localhost:25565). Only
-      # start.sh is missing: generated/ is gitignored, so we copy in the tracked launcher.
+      # generated/ is gitignored, so start.sh - the launcher example_plugin/README.md tells
+      # developers to hand-write - never made it into the provisioned run dir. Copy in the
+      # tracked copy.
       - name: Start the stand Paper server
         working-directory: ./example_plugin/src/test/e2e/generated/local/run
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,16 @@ jobs:
       # Running in parallel with test-example-plugin means this job can't reuse its
       # generated/local/run/ either - provision the same Paper server here instead of just
       # running plugwrightTest, which would also run (and duplicate) the local suite.
+      # plugwrightCompileTests is the other half: plugwrightPingStand/plugwrightTestStand
+      # don't depend on it themselves (ExternalMode assumes the stand is already up, nothing
+      # to provision - see registerTasks in ExternalMode.kt), they just expect node_modules
+      # to already have what npm(...) plugin refs and console { rcon {} } need.
       - uses: drownek/plugwright-action@v1
         with:
           java-version: "17"
           node-version: "24"
           working-directory: "./example_plugin"
+          gradle-args: plugwrightProvisionLocal plugwrightCompileTests
           gradle-args: plugwrightProvisionLocal
       # The provisioning above resolves a Java 21 toolchain for itself (build.gradle.kts pins
       # languageVersion 21 for Paper 1.21.11), but that's Gradle's own on-demand download, not

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
   test-example-plugin:
     if: "!contains(github.event.head_commit.message, 'skip-ci')"
     runs-on: ubuntu-latest
+    env:
+      # Test-only credentials for the Paper server this job starts and tears down itself.
+      PLUGWRIGHT_RCON_PASSWORD: plugwright
+      PLUGWRIGHT_BOT_PASSWORD: plugwright
 
     steps:
       - uses: actions/checkout@v4
@@ -32,3 +36,41 @@ jobs:
           java-version: "17"
           node-version: "24"
           working-directory: "./example_plugin"
+      # The LocalMode run above leaves Paper, cache and libraries under generated/local/run/ -
+      # stand reuses that same directory (build.gradle.kts points it at localhost:25565). Only
+      # start.sh is missing: generated/ is gitignored, so we copy in the tracked launcher.
+      - name: Start the stand Paper server
+        working-directory: ./example_plugin/src/test/e2e/generated/local/run
+        run: |
+          cp "$GITHUB_WORKSPACE/example_plugin/src/test/e2e/stand-run/start.sh" .
+          chmod +x start.sh
+          nohup ./start.sh > stand-server.log 2>&1 &
+          echo $! > stand-server.pid
+      - name: Wait for the stand server
+        working-directory: ./example_plugin
+        run: |
+          for i in $(seq 1 30); do
+            if ./gradlew plugwrightPingStand; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "stand server did not come up in time" >&2
+          exit 1
+      - name: Run the stand suite
+        working-directory: ./example_plugin
+        run: ./gradlew plugwrightTestStand
+      - name: Stop the stand Paper server
+        if: always()
+        working-directory: ./example_plugin/src/test/e2e/generated/local/run
+        run: |
+          [ -f stand-server.pid ] && kill "$(cat stand-server.pid)" 2>/dev/null || true
+      - name: Upload stand server log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stand-server-log
+          path: |
+            example_plugin/src/test/e2e/generated/local/run/stand-server.log
+            example_plugin/build/reports/plugwright/stand.*
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
           java-version: "17"
           node-version: "24"
           working-directory: "./example_plugin"
+      # LocalMode's own server launch resolves a Java 21 toolchain (build.gradle.kts pins
+      # languageVersion 21 for Paper 1.21.11) regardless of the Gradle-daemon JDK above - Gradle
+      # downloads it on demand. start.sh has no such resolution, it just runs whatever "java" is
+      # on PATH, so put a real JDK 21 there before it needs one.
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
       # The LocalMode run above leaves Paper, cache and libraries under generated/local/run/ -
       # stand reuses that same directory (build.gradle.kts points it at localhost:25565). Only
       # start.sh is missing: generated/ is gitignored, so we copy in the tracked launcher.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
           node-version: "24"
           working-directory: "./example_plugin"
           gradle-args: plugwrightProvisionLocal plugwrightCompileTests
-          gradle-args: plugwrightProvisionLocal
       # The provisioning above resolves a Java 21 toolchain for itself (build.gradle.kts pins
       # languageVersion 21 for Paper 1.21.11), but that's Gradle's own on-demand download, not
       # something start.sh can reach - it just runs whatever "java" is on PATH, which

--- a/example_plugin/README.md
+++ b/example_plugin/README.md
@@ -24,7 +24,7 @@ This one connects to a server that is already running and leaves it running. Pro
 cd src/test/e2e/generated/local/run && ./start.sh
 ```
 
-`generated/` is not in version control, so `start.sh` is yours to write. Anything that starts the jar with Java 21 will do:
+`generated/` is not in version control, so `start.sh` is yours to write. Anything that starts the jar with Java 21 will do — CI keeps a tracked copy at `src/test/e2e/stand-run/start.sh` and copies it in before starting the server:
 
 ```sh
 #!/usr/bin/env sh

--- a/example_plugin/src/test/e2e/stand-run/start.sh
+++ b/example_plugin/src/test/e2e/stand-run/start.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+# Tracked copy of the launcher example_plugin/README.md tells you to write yourself for a local
+# `stand` run. CI copies this into generated/local/run/ (see ci.yml) since that directory is
+# gitignored and can't hold a script of its own. Keep this in sync with the README snippet.
+set -e
+
+cd "$(dirname "$0")"
+
+JAVA_BIN="${JAVA_BIN:-java}"
+JVM_ARGS="${JVM_ARGS:--Xmx2G}"
+
+exec "$JAVA_BIN" $JVM_ARGS -Dcom.mojang.eula.agree=true -jar server.jar --nogui


### PR DESCRIPTION
Closes #61.

`test-example-plugin` only ever ran LocalMode — `stand` (ExternalMode) is `includeInMatrix: false` because it needs an already-running server, so `plugwrightTest` skips it and the RCON console channel, account-pool leasing and `justCreated` registration flow had zero CI coverage.

## What changed

- **`example_plugin/src/test/e2e/stand-run/start.sh`** (new, tracked): the launcher `example_plugin/README.md` already told developers to hand-write under `generated/local/run/`. That directory is gitignored, so CI had nothing to copy in — this commits the same script README documents, outside `generated/`.
- **`.gitattributes`** (new): pins `*.sh` to LF so a Windows checkout doesn't corrupt the shebang.
- **`example_plugin/README.md`**: one-line pointer to the tracked copy.
- **`.github/workflows/ci.yml`**: `stand` now runs as its own job, `test-example-plugin-stand`, in parallel with `test-example-plugin` (unchanged, keeps its name so an existing required-status-check on it still matches). Running on a separate runner means it can't reuse the local job's `generated/local/run/`, so it:
  1. Provisions its own Paper server via `plugwright-action`'s `gradle-args: plugwrightProvisionLocal plugwrightCompileTests` (provisioning alone isn't enough — `plugwrightPingStand`/`plugwrightTestStand` don't depend on `plugwrightCompileTests` themselves, they just expect `node_modules` already has what `console { rcon {} }` and the `npm(...)` plugin refs need; the old sequential job got this for free as a side effect of `plugwrightTest`'s own dependency chain).
  2. Installs a real JDK 21 (`actions/setup-java@v4`) before touching `start.sh` — Paper 1.21.11 needs it, but the Gradle daemon above runs on 17, and `start.sh` just execs whatever `java` is on `PATH`.
  3. Copies the tracked `start.sh` into the run dir, launches it backgrounded, saves its PID.
  4. Retry-loop `./gradlew plugwrightPingStand` (up to 30×2s) until the server answers — the built-in readiness probe (connects, probes the RCON console channel, leases + authenticates an account), not a raw port check.
  5. `./gradlew plugwrightTestStand` — blocking, same as LocalMode.
  6. `if: always()`: kill the backgrounded server by PID.
  7. `if: failure()`: upload the server log + `build/reports/plugwright/stand.*` as an artifact.

  `PLUGWRIGHT_RCON_PASSWORD` / `PLUGWRIGHT_BOT_PASSWORD` are set at job level as literal `plugwright` — test-only credentials for a server the job itself starts and tears down within the same run, matching `local`'s existing default.

No change to `plugwright-action` itself — its existing `gradle-args` input covered everything needed.

## Testing

Ran the sequence locally first: `plugwrightProvisionLocal` → copy tracked `start.sh` in → background start → ping retry-loop (ready on attempt 3) → `plugwrightTestStand`: **44/44 passed, 6 expected skips, 0 failed** → kill by PID confirmed the process exits.

CI itself went through a few iterations once the two jobs actually ran on separate runners (each caught something the single-job version had been masking as a side effect of task ordering):
- JDK 17-only PATH → `UnsupportedClassVersionError` starting Paper 1.21.11 → fixed by installing JDK 21 before `start.sh`.
- `plugwrightProvisionLocal` alone doesn't install `@plugwright/console-rcon` → every ping failed with "no console channel could be reached" → fixed by also running `plugwrightCompileTests`.

Final green run: `test-example-plugin` **pass in 4m58s**, `test-example-plugin-stand` **pass in 4m52s**, running concurrently — down from ~7m13s sequential.
