### PR TITLE
[v3] fix(gradle-plugin): make publish run both private and public repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,5 +52,5 @@ jobs:
           GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
         run: |
           chmod +x gradlew
-          ./gradlew publishToPublicRepository
+          ./gradlew publish
 

--- a/gradle-plugin/plugwright-bundle/build.gradle.kts
+++ b/gradle-plugin/plugwright-bundle/build.gradle.kts
@@ -168,3 +168,12 @@ tasks.register("publishToPrivateRepository") {
         }
     }
 }
+
+// `maven-publish` already registers `publish` as the lifecycle task for this module, but on
+// its own it only reaches the private repository above; the portal side lives under
+// `plugin-publish`'s `publishPlugins` and never joins it on its own. Wiring both wrapper
+// tasks onto `publish` makes it the one command a release runs, still skipping either side
+// exactly as `publishToPrivateRepository`/`publishToPublicRepository` do on their own.
+tasks.named("publish") {
+    dependsOn(tasks.named("publishToPrivateRepository"), tasks.named("publishToPublicRepository"))
+}


### PR DESCRIPTION
`plugwright-bundle` publishes to two places: a private maven repo (when `plugwright.publish.url` is set) and the Gradle Plugin Portal. Both already had their own task with an `enabled`-style switch — `publishToPrivateRepository` and `publishToPublicRepository` — but nothing tied them together. `maven-publish`'s own `publish` lifecycle task only reached the private side; the portal publish lives under `plugin-publish`'s `publishPlugins` and never joined it.

This wires both wrapper tasks onto `publish`, so `./gradlew publish` is the one command a release needs, and each side still turns itself off correctly when its repo isn't configured or its `enabled` property is `false`.

Also updated `release.yml`: it was calling `./gradlew publishToPublicRepository` directly, which skipped the private repo entirely. It now calls `./gradlew publish`.