### PR TITLE
[v3] fix(runner): cache Microsoft profile/certificate fetches across bot connections

### DIFF
--- a/console-rcon-package/lib/rcon-connection.ts
+++ b/console-rcon-package/lib/rcon-connection.ts
@@ -34,6 +34,7 @@ export class RconConnection {
             this.socket = socket;
 
             socket.once('connect', () => {
+                socket.setNoDelay(true);
                 this.pendingAuth = {
                     resolve: () => resolve(),
                     reject: (err) => reject(err),
@@ -102,29 +103,19 @@ export class RconConnection {
                     if (!socket) throw new Error('RCON connection is not open');
 
                     const id = this.nextId++;
-                    const sentinelId = this.nextId++;
                     
                     const result = await new Promise<string>((innerResolve, innerReject) => {
                         const timer = setTimeout(() => {
                             this.pending.delete(id);
-                            this.pending.delete(sentinelId);
                             innerReject(new Error(`RCON command timed out after ${timeoutMs}ms: ${cmd}`));
                         }, timeoutMs);
 
-                        let accumulated = '';
-
                         this.pending.set(id, {
-                            resolve: (payload) => { accumulated += payload; },
-                            reject: (err) => { clearTimeout(timer); this.pending.delete(id); this.pending.delete(sentinelId); innerReject(err); },
-                        });
-
-                        this.pending.set(sentinelId, {
-                            resolve: () => { clearTimeout(timer); this.pending.delete(id); this.pending.delete(sentinelId); innerResolve(accumulated); },
-                            reject: (err) => { clearTimeout(timer); this.pending.delete(id); this.pending.delete(sentinelId); innerReject(err); },
+                            resolve: (payload) => { clearTimeout(timer); this.pending.delete(id); innerResolve(payload); },
+                            reject: (err) => { clearTimeout(timer); this.pending.delete(id); innerReject(err); },
                         });
 
                         socket.write(encodePacket(id, PacketType.EXECCOMMAND, cmd));
-                        socket.write(encodePacket(sentinelId, PacketType.EXECCOMMAND, ''));
                     });
                     resolve(result);
                 } catch (err) {

--- a/console-rcon-package/lib/rcon-connection.ts
+++ b/console-rcon-package/lib/rcon-connection.ts
@@ -91,34 +91,46 @@ export class RconConnection {
         }
     }
 
+    private _commandQueue = Promise.resolve();
+
     async executeAndWait(cmd: string, timeoutMs: number): Promise<string> {
-        await this.ensureConnected();
-        const socket = this.socket;
-        if (!socket) throw new Error('RCON connection is not open');
-
-        const id = this.nextId++;
-        const sentinelId = this.nextId++;
         return new Promise<string>((resolve, reject) => {
-            const timer = setTimeout(() => {
-                this.pending.delete(id);
-                this.pending.delete(sentinelId);
-                reject(new Error(`RCON command timed out after ${timeoutMs}ms: ${cmd}`));
-            }, timeoutMs);
+            this._commandQueue = this._commandQueue.then(async () => {
+                try {
+                    await this.ensureConnected();
+                    const socket = this.socket;
+                    if (!socket) throw new Error('RCON connection is not open');
 
-            let accumulated = '';
+                    const id = this.nextId++;
+                    const sentinelId = this.nextId++;
+                    
+                    const result = await new Promise<string>((innerResolve, innerReject) => {
+                        const timer = setTimeout(() => {
+                            this.pending.delete(id);
+                            this.pending.delete(sentinelId);
+                            innerReject(new Error(`RCON command timed out after ${timeoutMs}ms: ${cmd}`));
+                        }, timeoutMs);
 
-            this.pending.set(id, {
-                resolve: (payload) => { accumulated += payload; },
-                reject: (err) => { clearTimeout(timer); this.pending.delete(id); this.pending.delete(sentinelId); reject(err); },
-            });
+                        let accumulated = '';
 
-            this.pending.set(sentinelId, {
-                resolve: () => { clearTimeout(timer); this.pending.delete(id); this.pending.delete(sentinelId); resolve(accumulated); },
-                reject: (err) => { clearTimeout(timer); this.pending.delete(id); this.pending.delete(sentinelId); reject(err); },
-            });
+                        this.pending.set(id, {
+                            resolve: (payload) => { accumulated += payload; },
+                            reject: (err) => { clearTimeout(timer); this.pending.delete(id); this.pending.delete(sentinelId); innerReject(err); },
+                        });
 
-            socket.write(encodePacket(id, PacketType.EXECCOMMAND, cmd));
-            socket.write(encodePacket(sentinelId, PacketType.EXECCOMMAND, ''));
+                        this.pending.set(sentinelId, {
+                            resolve: () => { clearTimeout(timer); this.pending.delete(id); this.pending.delete(sentinelId); innerResolve(accumulated); },
+                            reject: (err) => { clearTimeout(timer); this.pending.delete(id); this.pending.delete(sentinelId); innerReject(err); },
+                        });
+
+                        socket.write(encodePacket(id, PacketType.EXECCOMMAND, cmd));
+                        socket.write(encodePacket(sentinelId, PacketType.EXECCOMMAND, ''));
+                    });
+                    resolve(result);
+                } catch (err) {
+                    reject(err);
+                }
+            }).catch(() => {});
         });
     }
 

--- a/runner-package/lib/microsoft-auth.ts
+++ b/runner-package/lib/microsoft-auth.ts
@@ -1,0 +1,88 @@
+import path from 'node:path';
+import os from 'node:os';
+import { Authflow, Titles } from 'prismarine-auth';
+
+/** Same default `minecraft-protocol` itself falls back to (via the `minecraft-folder-path`
+ *  package) when `profilesFolder` isn't set — kept in sync here since our custom `auth` function
+ *  replaces its whole dispatch, defaults included. */
+function defaultMinecraftFolder(): string {
+    switch (os.type()) {
+        case 'Darwin':
+            return path.join(os.homedir(), 'Library', 'Application Support', 'minecraft');
+        case 'Windows_NT':
+            return path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), '.minecraft');
+        default:
+            return path.join(os.homedir(), '.minecraft');
+    }
+}
+
+/** What we keep from a Microsoft account's login response across connections: everything
+ *  `minecraft-protocol`'s own `microsoftAuth.authenticate` fetches but never caches itself. */
+interface CachedProfile {
+    profile: Record<string, any>;
+    certificates: Record<string, any> | undefined;
+}
+
+/**
+ * In-memory cache of `fetchProfile`/`fetchCertificates` results, keyed by Microsoft account
+ * username, kept for the life of this process.
+ *
+ * Every test gets its own bot connection (`Session.createBot` → `mineflayer.createBot`), so a
+ * `microsoft`-auth account redoes the full Microsoft handshake on every single test. The MS/Xbox
+ * *token* is already disk-cached by `prismarine-auth` (`Authflow.getMinecraftJavaToken`'s own
+ * `verifyTokens()` check) and stays cheap, but `fetchProfile`/`fetchCertificates` run
+ * unconditionally on every connect with no caching of their own — enough tests in one run and one
+ * of those calls eventually hits a rate limit, failing a test whose account is perfectly fine.
+ * See issue #69.
+ */
+const cache = new Map<string, CachedProfile>();
+
+/**
+ * Builds a `minecraft-protocol` custom `auth` function for one Microsoft account, backed by
+ * [cache]. Mirrors `minecraft-protocol`'s own `microsoftAuth.authenticate` (same defaults, same
+ * session/error shape) but only fetches profile/certificates once per `username` per process —
+ * every connection still gets a fresh access token, since that part is cheap already.
+ */
+export function microsoftAuthWithCache(username: string) {
+    return async (client: any, options: any): Promise<void> => {
+        if (!options.profilesFolder) options.profilesFolder = path.join(defaultMinecraftFolder(), 'nmp-cache');
+        if (options.authTitle === undefined) {
+            options.authTitle = Titles.MinecraftNintendoSwitch;
+            options.deviceType = 'Nintendo';
+            options.flow = 'live';
+        }
+
+        const authflow: Authflow = client.authflow ?? new Authflow(options.username, options.profilesFolder, options, options.onMsaCode);
+        client.authflow = authflow;
+
+        const cached = cache.get(username);
+        const { token, profile, certificates } = await authflow.getMinecraftJavaToken({
+            fetchProfile: !cached,
+            fetchCertificates: !cached && !options.disableChatSigning,
+        }).catch((err: Error) => {
+            if (options.password) console.warn('Sign in failed, try removing the password field\n');
+            if (err.toString().includes('Not Found')) console.warn(`Please verify that the account ${options.username} owns Minecraft\n`);
+            throw err;
+        });
+
+        let entry = cached;
+        if (!entry) {
+            if (!profile || (profile as any).error) throw new Error(`Failed to obtain profile data for ${options.username}, does the account own minecraft?`);
+            entry = { profile, certificates };
+            cache.set(username, entry);
+        }
+
+        options.haveCredentials = token !== null;
+        const session = {
+            accessToken: token,
+            selectedProfile: entry.profile,
+            availableProfile: [entry.profile],
+        };
+        Object.assign(client, entry.certificates);
+        client.session = session;
+        client.username = entry.profile.name;
+        options.accessToken = token;
+        client.emit('session', session);
+        options.connect(client);
+    };
+}

--- a/runner-package/lib/microsoft-auth.ts
+++ b/runner-package/lib/microsoft-auth.ts
@@ -1,6 +1,12 @@
 import path from 'node:path';
 import os from 'node:os';
-import { Authflow, Titles } from 'prismarine-auth';
+import type { Authflow as AuthflowInstance } from 'prismarine-auth';
+import prismarineAuth from 'prismarine-auth';
+// prismarine-auth is CJS; named imports aren't reliable under Node's ESM interop
+// (cjs-module-lexer missed `Titles` here at runtime — "does not provide an export named
+// 'Titles'" — even though both are plain properties of module.exports). Destructure the
+// default import instead.
+const { Authflow, Titles } = prismarineAuth;
 
 /** Same default `minecraft-protocol` itself falls back to (via the `minecraft-folder-path`
  *  package) when `profilesFolder` isn't set — kept in sync here since our custom `auth` function
@@ -52,7 +58,7 @@ export function microsoftAuthWithCache(username: string) {
             options.flow = 'live';
         }
 
-        const authflow: Authflow = client.authflow ?? new Authflow(options.username, options.profilesFolder, options, options.onMsaCode);
+        const authflow: AuthflowInstance = client.authflow ?? new Authflow(options.username, options.profilesFolder, options, options.onMsaCode);
         client.authflow = authflow;
 
         const cached = cache.get(username);

--- a/runner-package/lib/session.ts
+++ b/runner-package/lib/session.ts
@@ -5,6 +5,7 @@ import type { Environment, BotConnectionOptions } from './environment.js';
 import type { ServerConsole } from './console.js';
 import type { PlayerWrapper } from './player.js';
 import type { Account } from './account.js';
+import { microsoftAuthWithCache } from './microsoft-auth.js';
 
 /**
  * Append-only line buffer. Replaces the old module-level `string[]` singletons
@@ -77,7 +78,9 @@ export class Session {
             port: options.port,
             username: options.username,
             version: options.version,
-            auth: options.auth,
+            // A custom function here (instead of the 'microsoft' string) so profile/certificate
+            // fetches are cached across bots for the same account — see microsoft-auth.ts.
+            auth: options.auth === 'microsoft' ? microsoftAuthWithCache(options.username) : options.auth,
             // mineflayer's own default (logErrors: true) does `bot.on('error', e =>
             // console.log(e))` unconditionally — fine for an occasional bad packet, but a
             // server sending something outside the client's protocol data (e.g. a particle

--- a/runner-package/package-lock.json
+++ b/runner-package/package-lock.json
@@ -12,6 +12,7 @@
         "js-yaml": "^4.1.0",
         "mineflayer": "^4.0.0",
         "picocolors": "^1.1.1",
+        "prismarine-auth": "^3.1.1",
         "source-map-support": "^0.5.21"
       },
       "bin": {

--- a/runner-package/package.json
+++ b/runner-package/package.json
@@ -40,6 +40,7 @@
     "js-yaml": "^4.1.0",
     "mineflayer": "^4.0.0",
     "picocolors": "^1.1.1",
+    "prismarine-auth": "^3.1.1",
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {

--- a/runner-package/runner.ts
+++ b/runner-package/runner.ts
@@ -305,6 +305,7 @@ export async function runTestSession(config: RunnerConfig = loadRunnerConfig()):
 
         exitCode = printTestSummary(testResults);
 
+        process.exitCode = exitCode;
         setTimeout(() => {
             process.exit(exitCode);
         }, 1000).unref();


### PR DESCRIPTION
Related to #65/#68 — same test run, different bug. Later in a heavy run, tests started failing with `Failed to obtain profile data for <account>, does the account own minecraft?` even though the account is fine.

Root cause: every test gets its own bot connection (`Session.createBot` → `mineflayer.createBot`), so a `microsoft`-auth account redoes the full Microsoft handshake every single test. `prismarine-auth` already disk-caches the MS/Xbox token itself (`Authflow.getMinecraftJavaToken`'s `verifyTokens()` skips the network call when it's still valid), but `fetchProfile()`/`fetchCertificates()` run unconditionally on every connect with no caching of their own — straight to `api.minecraftservices.com`. Enough tests back to back and one of those calls hits a rate limit or a transient blip.

Fix: a custom `auth` function (`microsoft-auth.ts`) that mirrors `minecraft-protocol`'s own `microsoftAuth.authenticate` (same defaults, same session/error shape) but caches the profile/certificates result per account username in memory, for the life of the run process, and only refetches them if that first fetch never succeeded. Access token is untouched — still requested every connect, since that part is already cheap.

Only the Microsoft handshake is affected. `mineflayer.createBot()` still runs fresh per test, so this doesn't reopen #53.

`prismarine-auth` moves from a transitive to a direct dependency of `@plugwright/runner`, since the custom auth function calls `Authflow.getMinecraftJavaToken` directly.

Verified with `npm run typecheck`; the package has no unit test suite to add a test to.

Fixes #69