### PR TITLE
feat(runner): add afterAll hook for describe.serial block cleanup

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -65,6 +65,31 @@ describe.serial('kit lifecycle', () => {
 });
 ```
 
+### `afterAll(fn)`
+
+Registers a hook that runs once per instance of the enclosing `describe.serial` block, after its last executed test — whether the block finished all its tests, stopped early on a failure, or a test in it was skipped. Only valid inside `describe.serial`. Not called if the block never got its player (the initial connect failed). A throwing hook is logged, not fatal.
+
+<ParamField path="fn" type="(ctx: TestContext) => Promise<void> | void" required>
+  The cleanup hook.
+</ParamField>
+
+```typescript
+import { describe, test, afterAll } from '@plugwright/runner';
+
+describe.serial('vip trial', () => {
+  test('grants the trial permission', async ({ player, server }) => {
+    await server.execute(`lp user ${player.username} permission settemp vip.trial true 15m`);
+  });
+
+  afterAll(async ({ player, server }) => {
+    // Runs even if a later test in the block fails or gets skipped.
+    await server.execute(`lp user ${player.username} permission unsettemp vip.trial`);
+  });
+
+  test('sees the vip shop', async ({ player }) => { /* ... */ });
+});
+```
+
 ## `player` / `bot` Object
 
 The `player` or `bot` object represents a real Minecraft client connected to the test server.

--- a/docs/writing-tests.mdx
+++ b/docs/writing-tests.mdx
@@ -189,6 +189,27 @@ Each test starts with a clear message buffer, so a message from an earlier step 
 
 A block can't contain another `describe.serial` — nesting one ordered chain inside another is a scheduling question the runner deliberately doesn't answer.
 
+### Cleanup that must run no matter what
+
+`beforeEach`/`afterEach` skip a test entirely once the block has stopped — that's the point, the rest of the chain never ran. But some cleanup (revoking a permission you granted mid-block, releasing something outside the game world) needs to happen once regardless of which test failed or got skipped. That's what `afterAll` is for:
+
+```typescript
+describe.serial('vip trial', () => {
+  test('grants the trial permission', async ({ player, server }) => {
+    await server.execute(`lp user ${player.username} permission settemp vip.trial true 15m`);
+  });
+
+  afterAll(async ({ player, server }) => {
+    // Runs once, even if a later test in the block fails or gets skipped.
+    await server.execute(`lp user ${player.username} permission unsettemp vip.trial`);
+  });
+
+  test('sees the vip shop', async ({ player }) => { /* ... */ });
+});
+```
+
+It runs once per instance of the block, after the last test that actually executed, right before the plugins' own `afterEach`. The one case it skips is a block that never got its player — nothing happened yet, so there's nothing to clean up. A hook that throws gets logged and otherwise ignored; it won't turn a passing block into a failure.
+
 ### Naming an account
 
 On a stand where one specific account carries the state a scenario needs — a permission group, a starting balance, a whitelist entry — name it:

--- a/runner-package/lib/test-registry.ts
+++ b/runner-package/lib/test-registry.ts
@@ -61,6 +61,9 @@ export interface SerialBlock {
     requires: RequiresMap;
     environments: string[] | null;
     concurrency: number;
+    /** Registered via `afterAll()`, run once per instance of this block — after its last
+     *  executed test, whatever became of the rest. See `afterAll` below. */
+    afterAllHooks: Hook[];
 }
 
 export type RegistryItem =
@@ -159,7 +162,10 @@ function describeImpl(label: string, fn: () => void): void {
  *
  * Plugin `beforeEach`/`afterEach` run once around the block, not around each test in it: a
  * plugin that resets an account between tests would undo exactly what the block is built on.
- * `beforeEach`/`afterEach` declared in the spec still run for every test.
+ * `beforeEach`/`afterEach` declared in the spec still run for every test. `afterAll()` also
+ * runs once, after the block's last executed test — including when the block stopped early
+ * and skipped the rest — so it is the right place for cleanup that must happen once no matter
+ * how the block ended. See `afterAll` below.
  */
 function serialImpl(label: string, optionsOrFn: SerialOptions | (() => void), maybeFn?: () => void): void {
     const options = typeof optionsOrFn === 'function' ? {} : optionsOrFn;
@@ -177,6 +183,7 @@ function serialImpl(label: string, optionsOrFn: SerialOptions | (() => void), ma
         requires: options.requires ?? {},
         environments: options.environments ?? null,
         concurrency: normalizeConcurrency(options.concurrency),
+        afterAllHooks: [],
     };
 
     currentBlock = block;
@@ -205,4 +212,21 @@ export function beforeEach(hook: Hook): void {
 
 export function afterEach(hook: Hook): void {
     scopeStack[scopeStack.length - 1].afterHooks.push(hook);
+}
+
+/** Registers a hook that runs exactly once per instance of the enclosing `describe.serial`
+ *  block, after its last executed test — whether the block finished all its tests, stopped
+ *  early on a failure/timeout/`invalidatePlayer`, or a test in it was skipped. Unlike
+ *  `afterEach`, it is not called at all if the block never got its player (the initial connect
+ *  failed) — nothing ran, so there is nothing to clean up.
+ *
+ *  Only valid inside `describe.serial`: a plain `describe`/`test` has no single
+ *  block-completion moment to hang this on, since every test there gets its own bot and runs
+ *  independently. A throwing hook is logged, never fatal — it must not flip an otherwise
+ *  passing block into a failure. */
+export function afterAll(hook: Hook): void {
+    if (!currentBlock) {
+        throw new Error('afterAll: only valid inside describe.serial — a plain describe/test has no single block-completion event to run it on');
+    }
+    currentBlock.afterAllHooks.push(hook);
 }

--- a/runner-package/lib/test-runner.ts
+++ b/runner-package/lib/test-runner.ts
@@ -297,6 +297,9 @@ export async function runConcurrentTestCase(params: RunTestCaseParams & { concur
  * test after it is reported skipped rather than failed, because what they were written against
  * is a state the block never reached. Plugin `beforeEach`/`afterEach` wrap the block, not each
  * test: a plugin that resets an account between tests would undo what the block is built on.
+ * The block's own `afterAll` hooks run once after the last executed test, before the plugins'
+ * `afterEach` and before the bot disconnects — but only if a test actually ran; a block that
+ * never got its player has nothing to clean up.
  */
 export async function runSerialBlock(params: RunSerialBlockParams): Promise<TestResult[]> {
     const { file, block, session, plugins, connOpts, timeoutMs, pluginName = null, instance } = params;
@@ -392,7 +395,16 @@ export async function runSerialBlock(params: RunSerialBlockParams): Promise<Test
             }
         }
     } finally {
-        if (lastCtx) await plugins.afterEach(lastCtx);
+        if (lastCtx) {
+            for (const hook of [...block.afterAllHooks].reverse()) {
+                try {
+                    await hook(lastCtx);
+                } catch (error) {
+                    console.error(pc.red(`[serial ${block.name}] afterAll error: ${(error as Error).message}`));
+                }
+            }
+            await plugins.afterEach(lastCtx);
+        }
         await bots.close();
     }
 

--- a/runner-package/runner.ts
+++ b/runner-package/runner.ts
@@ -29,7 +29,7 @@ installSourceMapSupport();
 export { ItemWrapper, GuiWrapper, LiveGuiHandle, GuiItemLocator };
 export { PlayerWrapper };
 export { ServerWrapper } from './lib/server.js';
-export { test, describe, beforeEach, afterEach } from './lib/test-registry.js';
+export { test, describe, beforeEach, afterEach, afterAll } from './lib/test-registry.js';
 export type { TestOptions, TestCase, SerialOptions, SerialBlock, RequiresMap } from './lib/test-registry.js';
 export { expect } from './lib/matchers.js';
 export { loadRunnerConfig, resolveSecret, isSecretRef } from './lib/config.js';


### PR DESCRIPTION
## Problem

`describe.serial` has no hook that's guaranteed to run once the block is done, whatever "done" turned out to mean. `afterEach`/`ctx.cleanup()` are per-test: once the block stops early (a failure, a timeout, `invalidatePlayer`), every remaining test is reported skipped and its body — and any cleanup registered inside it — never runs. There's no way to write "revoke this permission / release this resource no matter which test in the block failed."

## Fix

Adds `afterAll(hook)`, importable alongside `test`/`describe`/`beforeEach`/`afterEach`. Only valid inside `describe.serial` — a plain `describe`/`test` has no single block-completion event to hang it on, and calling it outside a block throws immediately at registration time.

It runs:
- once per instance of the block (so `concurrency: 5` runs it 5 times, once per bot)
- after the last test that actually executed — whether the block finished cleanly, stopped early, or a test in it was skipped
- before the plugins' own `afterEach` and before the bot disconnects
- **not at all** if the block never got its player (the initial connect failed) — nothing ran, so there's nothing to clean up

A throwing `afterAll` hook is logged (`[serial <block>] afterAll error: ...`) and never flips the block's result, matching how `ctx.cleanup()` finalizer errors are already handled.

```typescript
describe.serial('vip trial', () => {
  test('grants the trial permission', async ({ player, server }) => {
    await server.execute(`lp user ${player.username} permission settemp vip.trial true 15m`);
  });

  afterAll(async ({ player, server }) => {
    // Runs once, even if a later test in the block fails or gets skipped.
    await server.execute(`lp user ${player.username} permission unsettemp vip.trial`);
  });

  test('sees the vip shop', async ({ player }) => { /* ... */ });
});
```

## Changes

- `test-registry.ts`: `SerialBlock.afterAllHooks`, `afterAll()` export
- `test-runner.ts`: `runSerialBlock` runs the block's `afterAllHooks` (LIFO, try/catch-logged) in its `finally`, gated on `lastCtx` (mirrors the existing `plugins.afterEach(lastCtx)` gate)
- `runner.ts`: re-exports `afterAll`
- `docs/writing-tests.mdx`, `docs/api-reference.mdx`: document the hook

## Verification

`tsc --noEmit` clean. No existing behavior touched outside the `runSerialBlock` `finally` block and the registry's block construction.
